### PR TITLE
fix 'Abort' button bug

### DIFF
--- a/batch_convert.qml
+++ b/batch_convert.qml
@@ -686,7 +686,8 @@ MuseScore {
         }
       
       // next file
-      processTimer.running = true
+      if(!abortRequested)
+            processTimer.running = true
       }
     }
 


### PR DESCRIPTION
When I worked on adding functionality back to the core, I found a bug in the plugin itself. When the user clicked on 'Abort', the plugin's dialog window would disappear, but the plugin would still continue to work (in background, which I saw on the console). The abortRequest variable was only checked when all files were processed. I think this should fix the problem.