### PR TITLE
Fixes error where the 'export parts' checkbox is not shown for Musescore versions >= 3.1.0

### DIFF
--- a/batch_convert.qml
+++ b/batch_convert.qml
@@ -337,7 +337,7 @@ MuseScore {
         CheckBox {
           id: exportExcerpts
           text: /*qsTr("Export linked parts")*/ qsTranslate("action", "Export parts")
-          enabled: (mscoreMajorVersion == 3 && mscoreMinorVersion == 0 && mscoreUpdateVersion > 2) ? true : false // MuseScore > 3.0.2
+          enabled: (mscoreMajorVersion == 3 && mscoreMinorVersion > 0 || (mscoreMinorVersion == 0 && mscoreUpdateVersion > 2)) ? true : false // MuseScore > 3.0.2
           visible: enabled //  hide if not enabled
           } // exportExcerpts
         CheckBox {


### PR DESCRIPTION
Fixes error where the 'export parts' checkbox is not shown for Musescore versions >= 3.1.0